### PR TITLE
Fix qadz off-by-one, binary output mode, Windows build compatibility

### DIFF
--- a/compression/XipZ/Makefile
+++ b/compression/XipZ/Makefile
@@ -8,7 +8,7 @@ else
   HD = hd
 endif
 
-VERSION = 0.6.0
+VERSION = 0.6.1
 #
 OBJS = cmdline.o qadz.o xipz.o lzp.o
 #

--- a/compression/XipZ/Makefile
+++ b/compression/XipZ/Makefile
@@ -2,6 +2,12 @@
 
 CXXFLAGS = -DNDEBUG -Wall -O2 -Wextra -std=c++23
 
+ifeq ($(OS),Windows_NT)
+  HD = xxd
+else
+  HD = hd
+endif
+
 VERSION = 0.6.0
 #
 OBJS = cmdline.o qadz.o xipz.o lzp.o
@@ -51,7 +57,7 @@ decrunchxipzstub:	decrunchxipzstub.s
 
 %.inc:	%
 	xxd -i $< > $@
-	hd $<
+	$(HD) $<
 
 decrunchqadzstub:	decrunchqadzstub.s
 	cl65 --asm-include-dir ../../library -C c64-asm.cfg  -Ln $@.label -m $@.map --listing $@.lst $+

--- a/compression/XipZ/command_line.ggo
+++ b/compression/XipZ/command_line.ggo
@@ -1,5 +1,5 @@
 package "XipZ"
-version "0.6.0"
+version "0.6.1"
 args	"--unnamed-opts"
 option	"raw"	r "output raw crunched data without header" flag off
 option	"algorithm"	a "crunching algorithm to use" values="xipz","qadz","lzp" enum default="xipz" optional

--- a/compression/XipZ/decrunchqadzstub.s
+++ b/compression/XipZ/decrunchqadzstub.s
@@ -54,12 +54,14 @@ literal:
 	tax			; Keep number of bytes safe.
 	tay			; Put number of bytes into index register.
 	inc	SRCPTR		; increment src
-	bne	litcop
+	bne	@litpre		; skip high-byte increment if no carry
 	inc	SRCPTR+1
+@litpre:
+	dey			; start at count-1 so loop covers positions [count-1..0]
 litcop:	lda	(SRCPTR),y
 	sta	(DSTPTR),y
 	dey
-	bpl	litcop
+	bpl	litcop		; exit when Y wraps to $FF (after position 0)
 	jsr	incsrc
 	jsr	incdst
 	jmp	decrunch
@@ -85,7 +87,7 @@ bckcop:	lda	(AUXPTR),y
 	sta	(DSTPTR),y
 	iny			; Now go to next byte.
 	dex			; Decrement the counter.
-	bpl	bckcop
+	bne	bckcop
 	lda	#0		; Placeholder for run length.
 	sm_runlen = *-1
 	jsr	incdstA		; Adjust destination.

--- a/compression/XipZ/xipz.cc
+++ b/compression/XipZ/xipz.cc
@@ -479,7 +479,7 @@ int main_qadz(const std::string &inputname, const std::string &outputname, bool 
   Data data(read_data(inputname, exloadaddr));
   std::vector<uint8_t> compressed(crunch_qadz(data));
   std::cout << "Compressed size: " << compressed.size() << std::endl;
-  std::ofstream out(outputname);
+  std::ofstream out(outputname, std::ios::binary);
   if(!raw) {
     if(jump >= 0) {
       jumpaddr = jump;
@@ -510,7 +510,7 @@ int main_lzp(const std::string &inputname, const std::string &outputname, bool r
   Data data(read_data(inputname, exloadaddr));
   std::vector<uint8_t> compressed(crunch_lzp(data));
   std::cout << "Compressed size: " << compressed.size() << std::endl;
-  std::ofstream out(outputname);
+  std::ofstream out(outputname, std::ios::binary);
   if(!raw) {
     if(jump >= 0) {
       jumpaddr = jump;


### PR DESCRIPTION
Fixes Windows compatibility by enforcing binary stream mode and adjusting Makefile hex dump utilities.
Resolves an off-by-one loop condition bug in the assembly decruncher stub.